### PR TITLE
ADD OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- serverless-approvers
+
+reviewers:
+- serverless-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,25 @@
+aliases:
+  serverless-approvers:
+  - alanfx
+  - aliok
+  - jcrossley3
+  - lberk
+  - matzew
+  - mgencur
+  - nak3
+  - openshift-cherrypick-robot
+  - pierDipi
+  - rhuss
+  - skonto
+  serverless-reviewers:
+  - alanfx
+  - aliok
+  - dsimansk
+  - jcrossley3
+  - lberk
+  - matzew
+  - mgencur
+  - nak3
+  - pierDipi
+  - rhuss
+  - skonto


### PR DESCRIPTION
It seems OWNERS file does not exist and could not approve the PR - https://github.com/openshift-knative/must-gather/pull/6

This patch adds OWNERS files just by copying from SO repo. 